### PR TITLE
update alpine-extra variant to alpine 3.16

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.15
+FROM alpine:3.16
 
 MAINTAINER Kamran Azeem & Henrik Høegh (kamranazeem@gmail.com, henrikrhoegh@gmail.com )
 


### PR DESCRIPTION
- Update to alpine 3.16
- Trigger rebuild to fix 23 critical, 203 high, 60 medium, and 2 low vulnerabilities detected in the current `alpine-extra` release